### PR TITLE
Add patient encounter scenario with supervisory evaluation

### DIFF
--- a/src/app/agentConfigs/index.ts
+++ b/src/app/agentConfigs/index.ts
@@ -1,6 +1,7 @@
 import { simpleHandoffScenario } from './simpleHandoff';
 import { customerServiceRetailScenario } from './customerServiceRetail';
 import { chatSupervisorScenario } from './chatSupervisor';
+import { patientEncounter } from './patientEncounter';
 
 import type { RealtimeAgent } from '@openai/agents/realtime';
 
@@ -9,6 +10,7 @@ export const allAgentSets: Record<string, RealtimeAgent[]> = {
   simpleHandoff: simpleHandoffScenario,
   customerServiceRetail: customerServiceRetailScenario,
   chatSupervisor: chatSupervisorScenario,
+  patientEncounter: patientEncounter,
 };
 
 export const defaultAgentSetKey = 'chatSupervisor';

--- a/src/app/agentConfigs/patientEncounter.ts
+++ b/src/app/agentConfigs/patientEncounter.ts
@@ -1,0 +1,48 @@
+import { RealtimeAgent, RealtimeSession } from '@openai/agents/realtime';
+
+export const patientAgent = new RealtimeAgent({
+  name: 'patient',
+  voice: 'alloy',
+  instructions: `
+You are playing the role of a patient in a primary care visit. Begin the encounter with the line:
+"I'm having chest pain and feel short of breath."
+
+Provide history only when the clinician asks. Your scripted history:
+- Onset: 2 days ago after climbing stairs.
+- Pain: sharp, 6/10, radiates to left arm.
+- Associated: mild nausea, sweating.
+- Past medical history: hypertension, no surgeries, allergy to penicillin.
+- Medications: lisinopril 10mg daily.
+- Social: smokes half a pack/day, drinks wine on weekends.
+
+Keep answers brief and first-person. Do not invent new symptoms.
+`,
+  handoffs: [],
+  tools: [],
+});
+
+export const supervisorAgent = new RealtimeAgent({
+  name: 'encounterSupervisor',
+  voice: 'alloy',
+  instructions: `
+You are a clinical supervisor observing a patient encounter between the user and the patient agent.
+Subscribe to conversation events and evaluate the clinician's performance.
+Provide short feedback after each clinician message. Do not speak to the patient directly.
+`,
+  handoffs: [],
+  tools: [],
+});
+
+export function registerPatientEncounterSupervisor(session: RealtimeSession) {
+  session.on('agent_end', async (ctx: any, agent: any, output: string) => {
+    if (agent.name === patientAgent.name) return;
+    const evaluation = await (supervisorAgent as any).run(
+      `Evaluate the clinician's response: ${output}`,
+      { context: ctx },
+    );
+    console.log('[encounterSupervisor]', evaluation);
+  });
+}
+
+export const patientEncounter = [patientAgent];
+export default patientEncounter;


### PR DESCRIPTION
## Summary
- add patient encounter scenario with scripted patient prompts
- include supervisor agent that evaluates conversation via event subscription
- register new scenario in agent config index

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5d7292fb48329b1059a1d3ab2aa73