### PR TITLE
Initialize session with patientEncounter agents

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -24,8 +24,10 @@ import { createModerationGuardrail } from "@/app/agentConfigs/guardrails";
 import { allAgentSets, defaultAgentSetKey } from "@/app/agentConfigs";
 import { customerServiceRetailScenario } from "@/app/agentConfigs/customerServiceRetail";
 import { chatSupervisorScenario } from "@/app/agentConfigs/chatSupervisor";
+import { patientEncounterScenario } from "@/app/agentConfigs/patientEncounter";
 import { customerServiceRetailCompanyName } from "@/app/agentConfigs/customerServiceRetail";
 import { chatSupervisorCompanyName } from "@/app/agentConfigs/chatSupervisor";
+import { patientEncounterCompanyName } from "@/app/agentConfigs/patientEncounter";
 import { simpleHandoffScenario } from "@/app/agentConfigs/simpleHandoff";
 
 // Map used by connect logic for scenarios defined via the SDK.
@@ -33,6 +35,7 @@ const sdkScenarioMap: Record<string, RealtimeAgent[]> = {
   simpleHandoff: simpleHandoffScenario,
   customerServiceRetail: customerServiceRetailScenario,
   chatSupervisor: chatSupervisorScenario,
+  patientEncounter: patientEncounterScenario,
 };
 
 import useAudioDownload from "./hooks/useAudioDownload";
@@ -214,7 +217,9 @@ function App() {
 
         const companyName = agentSetKey === 'customerServiceRetail'
           ? customerServiceRetailCompanyName
-          : chatSupervisorCompanyName;
+          : agentSetKey === 'patientEncounter'
+            ? patientEncounterCompanyName
+            : chatSupervisorCompanyName;
         const guardrail = createModerationGuardrail(companyName);
 
         await connect({

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -38,6 +38,12 @@ const sdkScenarioMap: Record<string, RealtimeAgent[]> = {
   patientEncounter: patientEncounterScenario,
 };
 
+const agentCompanyNames: Record<string, string> = {
+  customerServiceRetail: customerServiceRetailCompanyName,
+  patientEncounter: patientEncounterCompanyName,
+  chatSupervisor: chatSupervisorCompanyName,
+};
+
 import useAudioDownload from "./hooks/useAudioDownload";
 import { useHandleSessionHistory } from "./hooks/useHandleSessionHistory";
 
@@ -215,11 +221,7 @@ function App() {
           reorderedAgents.unshift(agent);
         }
 
-        const companyName = agentSetKey === 'customerServiceRetail'
-          ? customerServiceRetailCompanyName
-          : agentSetKey === 'patientEncounter'
-            ? patientEncounterCompanyName
-            : chatSupervisorCompanyName;
+        const companyName = agentCompanyNames[agentSetKey] ?? chatSupervisorCompanyName;
         const guardrail = createModerationGuardrail(companyName);
 
         await connect({

--- a/src/app/agentConfigs/index.ts
+++ b/src/app/agentConfigs/index.ts
@@ -1,6 +1,7 @@
 import { simpleHandoffScenario } from './simpleHandoff';
 import { customerServiceRetailScenario } from './customerServiceRetail';
 import { chatSupervisorScenario } from './chatSupervisor';
+import { patientEncounterScenario } from './patientEncounter';
 
 import type { RealtimeAgent } from '@openai/agents/realtime';
 
@@ -9,6 +10,7 @@ export const allAgentSets: Record<string, RealtimeAgent[]> = {
   simpleHandoff: simpleHandoffScenario,
   customerServiceRetail: customerServiceRetailScenario,
   chatSupervisor: chatSupervisorScenario,
+  patientEncounter: patientEncounterScenario,
 };
 
-export const defaultAgentSetKey = 'chatSupervisor';
+export const defaultAgentSetKey = 'patientEncounter';

--- a/src/app/agentConfigs/patientEncounter.ts
+++ b/src/app/agentConfigs/patientEncounter.ts
@@ -27,5 +27,3 @@ export const patientEncounterScenario = [intakeAgent, clinicianAgent];
 
 // Name of the organization represented by this agent set. Used by guardrails
 export const patientEncounterCompanyName = 'Acme Health';
-
-export default patientEncounterScenario;

--- a/src/app/agentConfigs/patientEncounter.ts
+++ b/src/app/agentConfigs/patientEncounter.ts
@@ -1,0 +1,31 @@
+import { RealtimeAgent } from '@openai/agents/realtime';
+
+export const intakeAgent = new RealtimeAgent({
+  name: 'intake',
+  voice: 'alloy',
+  instructions:
+    'Greet the patient, collect basic information about their concern, then hand off to the clinician agent.',
+  handoffs: [],
+  tools: [],
+  handoffDescription: 'Initial triage agent',
+});
+
+export const clinicianAgent = new RealtimeAgent({
+  name: 'clinician',
+  voice: 'sage',
+  instructions:
+    'Provide concise medical guidance based on the information gathered by the intake agent.',
+  handoffs: [],
+  tools: [],
+  handoffDescription: 'Primary clinician',
+});
+
+// Allow the intake agent to hand off to clinician
+intakeAgent.handoffs = [clinicianAgent];
+
+export const patientEncounterScenario = [intakeAgent, clinicianAgent];
+
+// Name of the organization represented by this agent set. Used by guardrails
+export const patientEncounterCompanyName = 'Acme Health';
+
+export default patientEncounterScenario;


### PR DESCRIPTION
## Summary
- add patient encounter agent scenario and default to it
- hook session initialization to patient encounter agents and company-specific guardrail

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5d8701124832980e0b4c497fbfde0