### PR TITLE
chore: scaffold medical interview scenario

### DIFF
--- a/src/app/agentConfigs/index.ts
+++ b/src/app/agentConfigs/index.ts
@@ -2,6 +2,7 @@ import { simpleHandoffScenario } from './simpleHandoff';
 import { customerServiceRetailScenario } from './customerServiceRetail';
 import { chatSupervisorScenario } from './chatSupervisor';
 import { patientEncounter } from './patientEncounter';
+import { medicalInterviewScenario } from './medicalInterview';
 
 import type { RealtimeAgent } from '@openai/agents/realtime';
 
@@ -11,6 +12,7 @@ export const allAgentSets: Record<string, RealtimeAgent[]> = {
   customerServiceRetail: customerServiceRetailScenario,
   chatSupervisor: chatSupervisorScenario,
   patientEncounter: patientEncounter,
+  medicalInterview: medicalInterviewScenario,
 };
 
 export const defaultAgentSetKey = 'chatSupervisor';

--- a/src/app/agentConfigs/medicalInterview/cases.ts
+++ b/src/app/agentConfigs/medicalInterview/cases.ts
@@ -1,0 +1,3 @@
+export const medicalInterviewCases: string[] = [];
+
+export default medicalInterviewCases;

--- a/src/app/agentConfigs/medicalInterview/examCoach.ts
+++ b/src/app/agentConfigs/medicalInterview/examCoach.ts
@@ -1,0 +1,10 @@
+import { RealtimeAgent } from '@openai/agents/realtime';
+
+export const examCoachAgent = new RealtimeAgent({
+  name: 'examCoach',
+  instructions: `You provide coaching after the interview.`,
+  handoffs: [],
+  tools: [],
+});
+
+export default examCoachAgent;

--- a/src/app/agentConfigs/medicalInterview/feedback.ts
+++ b/src/app/agentConfigs/medicalInterview/feedback.ts
@@ -1,0 +1,6 @@
+export function getFeedback() {
+  // Placeholder for feedback logic
+  return 'Feedback placeholder';
+}
+
+export default getFeedback;

--- a/src/app/agentConfigs/medicalInterview/index.ts
+++ b/src/app/agentConfigs/medicalInterview/index.ts
@@ -1,0 +1,14 @@
+import { interviewerAgent } from './interviewer';
+import { examCoachAgent } from './examCoach';
+
+export { getFeedback } from './feedback';
+export { medicalInterviewStateMachine } from './stateMachine';
+export { medicalInterviewRubrics } from './rubrics';
+export { medicalInterviewCases } from './cases';
+
+export const medicalInterviewScenario = [
+  interviewerAgent,
+  examCoachAgent,
+];
+
+export default medicalInterviewScenario;

--- a/src/app/agentConfigs/medicalInterview/interviewer.ts
+++ b/src/app/agentConfigs/medicalInterview/interviewer.ts
@@ -1,0 +1,10 @@
+import { RealtimeAgent } from '@openai/agents/realtime';
+
+export const interviewerAgent = new RealtimeAgent({
+  name: 'medicalInterviewer',
+  instructions: `You are a medical interviewer conducting a simulated patient encounter.`,
+  handoffs: [],
+  tools: [],
+});
+
+export default interviewerAgent;

--- a/src/app/agentConfigs/medicalInterview/rubrics.ts
+++ b/src/app/agentConfigs/medicalInterview/rubrics.ts
@@ -1,0 +1,3 @@
+export const medicalInterviewRubrics: string[] = [];
+
+export default medicalInterviewRubrics;

--- a/src/app/agentConfigs/medicalInterview/stateMachine.ts
+++ b/src/app/agentConfigs/medicalInterview/stateMachine.ts
@@ -1,0 +1,6 @@
+export const medicalInterviewStateMachine = {
+  // Placeholder state machine definition
+  initial: 'start',
+};
+
+export default medicalInterviewStateMachine;


### PR DESCRIPTION
## Summary
- add medical interview scenario with interviewer and exam coach agents
- scaffold placeholder modules for feedback, state machine, rubrics, and cases
- register medical interview scenario in agent config index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6c1a7f55083299440931cc73fcd53