### PR TITLE
Add interviewer tools and server endpoints

### DIFF
--- a/src/app/agentConfigs/medicalInterview/interviewer.ts
+++ b/src/app/agentConfigs/medicalInterview/interviewer.ts
@@ -1,10 +1,88 @@
-import { RealtimeAgent } from '@openai/agents/realtime';
+import { RealtimeAgent, tool } from '@openai/agents/realtime';
+
+async function callInterviewerApi(action: string, args: any = {}) {
+  try {
+    const res = await fetch('/api/interviewer', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ action, args }),
+    });
+    return await res.json();
+  } catch {
+    // Safe default no-op
+    return { ok: true };
+  }
+}
 
 export const interviewerAgent = new RealtimeAgent({
   name: 'medicalInterviewer',
   instructions: `You are a medical interviewer conducting a simulated patient encounter.`,
   handoffs: [],
-  tools: [],
+  tools: [
+    tool({
+      name: 'timer.start',
+      description: 'Start a countdown timer for the given number of milliseconds.',
+      parameters: {
+        type: 'object',
+        properties: {
+          ms: { type: 'number', description: 'Duration in milliseconds' },
+        },
+        required: ['ms'],
+        additionalProperties: false,
+      },
+      execute: async (input: any) => callInterviewerApi('timer.start', input),
+    }),
+    tool({
+      name: 'timer.stop',
+      description: 'Stop the active timer and return elapsed time.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      execute: async () => callInterviewerApi('timer.stop'),
+    }),
+    tool({
+      name: 'score.add',
+      description: 'Add a score for a specific domain with optional reason.',
+      parameters: {
+        type: 'object',
+        properties: {
+          domain: { type: 'string', description: 'Domain or category for the score' },
+          points: { type: 'number', description: 'Points to add' },
+          reason: { type: 'string', description: 'Optional reason for the score' },
+        },
+        required: ['domain', 'points'],
+        additionalProperties: false,
+      },
+      execute: async (input: any) => callInterviewerApi('score.add', input),
+    }),
+    tool({
+      name: 'note.append',
+      description: 'Append a note to the session record.',
+      parameters: {
+        type: 'object',
+        properties: {
+          text: { type: 'string', description: 'Note text to append' },
+        },
+        required: ['text'],
+        additionalProperties: false,
+      },
+      execute: async (input: any) => callInterviewerApi('note.append', input),
+    }),
+    tool({
+      name: 'export.session',
+      description: 'Export the current session data including notes and scores.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      execute: async () => callInterviewerApi('export.session'),
+    }),
+  ],
 });
 
 export default interviewerAgent;

--- a/src/app/api/interviewer/route.ts
+++ b/src/app/api/interviewer/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+interface ScoreEntry {
+  domain: string;
+  points: number;
+  reason?: string;
+}
+
+let timerStart: number | null = null;
+let timerTimeout: NodeJS.Timeout | null = null;
+const notes: string[] = [];
+const scores: ScoreEntry[] = [];
+
+export async function POST(req: NextRequest) {
+  try {
+    const { action, args = {} } = await req.json();
+
+    switch (action) {
+      case 'timer.start': {
+        const ms = typeof args.ms === 'number' ? args.ms : undefined;
+        if (typeof ms === 'number') {
+          timerStart = Date.now();
+          if (timerTimeout) clearTimeout(timerTimeout);
+          timerTimeout = setTimeout(() => {
+            timerStart = null;
+            timerTimeout = null;
+          }, ms);
+          return NextResponse.json({ status: 'started', ms });
+        }
+        return NextResponse.json({ status: 'ignored' });
+      }
+      case 'timer.stop': {
+        if (timerStart !== null) {
+          const elapsed = Date.now() - timerStart;
+          timerStart = null;
+          if (timerTimeout) {
+            clearTimeout(timerTimeout);
+            timerTimeout = null;
+          }
+          return NextResponse.json({ status: 'stopped', elapsed_ms: elapsed });
+        }
+        return NextResponse.json({ status: 'no_timer' });
+      }
+      case 'score.add': {
+        const { domain, points, reason } = args as ScoreEntry;
+        if (typeof domain === 'string' && typeof points === 'number') {
+          scores.push({ domain, points, reason });
+          return NextResponse.json({ status: 'recorded' });
+        }
+        return NextResponse.json({ status: 'ignored' });
+      }
+      case 'note.append': {
+        const { text } = args as { text?: string };
+        if (typeof text === 'string') {
+          notes.push(text);
+          return NextResponse.json({ status: 'noted' });
+        }
+        return NextResponse.json({ status: 'ignored' });
+      }
+      case 'export.session': {
+        return NextResponse.json({
+          notes,
+          scores,
+          timer: timerStart,
+        });
+      }
+      default:
+        return NextResponse.json({ status: 'unknown_action' }, { status: 400 });
+    }
+  } catch {
+    // Fail-safe no-op
+    return NextResponse.json({ status: 'error' }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add timing, scoring, note-taking, and session-export tools to the medical interviewer agent
- implement corresponding server endpoint with in-memory logic and safe no-ops

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6c6178c2883298c9db5679335e1f4