### PR TITLE
feat: add medical interview controls

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import Image from "next/image";
 import Transcript from "./components/Transcript";
 import Events from "./components/Events";
 import BottomToolbar from "./components/BottomToolbar";
+import MedicalInterviewControls from "./components/MedicalInterviewControls";
 
 // Types
 import { SessionStatus } from "@/app/types";
@@ -511,9 +512,11 @@ function App() {
                 </div>
               </div>
             </div>
-          )}
+      )}
         </div>
       </div>
+
+      {agentSetKey === "medicalInterview" && <MedicalInterviewControls />}
 
       <div className="flex flex-1 gap-2 px-2 overflow-hidden relative">
         <Transcript

--- a/src/app/components/MedicalInterviewControls.tsx
+++ b/src/app/components/MedicalInterviewControls.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React from "react";
+import { useMedicalInterview } from "@/app/contexts/MedicalInterviewContext";
+import { useTranscript } from "@/app/contexts/TranscriptContext";
+
+function formatTime(ms: number) {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = (totalSeconds % 60).toString().padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}
+
+export default function MedicalInterviewControls() {
+  const {
+    timerMs,
+    timerRunning,
+    totalScore,
+    stateTag,
+    startTimer,
+    stopTimer,
+  } = useMedicalInterview();
+  const { addTranscriptToolCall } = useTranscript();
+
+  const handleStart = async () => {
+    try {
+      await fetch("/api/interviewer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "timer.start", args: { ms: 600000 } }),
+      });
+    } catch {}
+    startTimer();
+    addTranscriptToolCall("timer.start", { ms: 600000 });
+  };
+
+  const handleStop = async () => {
+    try {
+      await fetch("/api/interviewer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "timer.stop" }),
+      });
+    } catch {}
+    stopTimer();
+    addTranscriptToolCall("timer.stop");
+  };
+
+  const handleExport = async () => {
+    try {
+      const res = await fetch("/api/interviewer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "export.session" }),
+      });
+      const data = await res.json();
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "session.json";
+      a.click();
+      URL.revokeObjectURL(url);
+      addTranscriptToolCall("export.session", data);
+    } catch {}
+  };
+
+  return (
+    <div className="p-4 bg-white border-b flex items-center gap-4 text-sm">
+      <button
+        onClick={timerRunning ? handleStop : handleStart}
+        className="px-3 py-1 rounded-md bg-black text-white"
+      >
+        {timerRunning ? "Stop" : "Start"}
+      </button>
+      <div>Timer: {formatTime(timerMs)}</div>
+      <div>Score: {totalScore}</div>
+      <div className="px-2 py-1 bg-gray-200 rounded">{stateTag}</div>
+      <button
+        onClick={handleExport}
+        className="px-3 py-1 rounded-md bg-gray-200"
+      >
+        Export
+      </button>
+    </div>
+  );
+}
+

--- a/src/app/components/Transcript.tsx
+++ b/src/app/components/Transcript.tsx
@@ -194,6 +194,39 @@ function Transcript({
                   )}
                 </div>
               );
+            } else if (type === "TOOL_CALL") {
+              return (
+                <div
+                  key={itemId}
+                  className="flex flex-col justify-start items-start text-gray-500 text-sm"
+                >
+                  <span className="text-xs font-mono">{timestamp}</span>
+                  <div
+                    className={`whitespace-pre-wrap flex items-center font-mono text-sm text-gray-800 ${
+                      data ? "cursor-pointer" : ""
+                    }`}
+                    onClick={() => data && toggleTranscriptItemExpand(itemId)}
+                  >
+                    {data && (
+                      <span
+                        className={`text-gray-400 mr-1 transform transition-transform duration-200 select-none font-mono ${
+                          expanded ? "rotate-90" : "rotate-0"
+                        }`}
+                      >
+                        ▶
+                      </span>
+                    )}
+                    {title}
+                  </div>
+                  {expanded && data && (
+                    <div className="text-gray-800 text-left">
+                      <pre className="border-l-2 ml-1 border-gray-200 whitespace-pre-wrap break-words font-mono text-xs mb-2 mt-2 pl-2">
+                        {JSON.stringify(data, null, 2)}
+                      </pre>
+                    </div>
+                  )}
+                </div>
+              );
             } else {
               // Fallback if type is neither MESSAGE nor BREADCRUMB
               return (

--- a/src/app/contexts/MedicalInterviewContext.tsx
+++ b/src/app/contexts/MedicalInterviewContext.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState, PropsWithChildren } from "react";
+
+interface ScoreEntry {
+  domain: string;
+  points: number;
+  reason?: string;
+}
+
+interface MedicalInterviewContextValue {
+  timerMs: number;
+  timerRunning: boolean;
+  scores: ScoreEntry[];
+  totalScore: number;
+  stateTag: string;
+  startTimer: () => void;
+  stopTimer: () => void;
+  addScore: (entry: ScoreEntry) => void;
+  setStateTag: (state: string) => void;
+}
+
+const MedicalInterviewContext = createContext<MedicalInterviewContextValue | undefined>(undefined);
+
+export const MedicalInterviewProvider = ({ children }: PropsWithChildren) => {
+  const [timerStart, setTimerStart] = useState<number | null>(null);
+  const [timerMs, setTimerMs] = useState(0);
+  const [scores, setScores] = useState<ScoreEntry[]>([]);
+  const [stateTag, setStateTag] = useState("IDLE");
+
+  useEffect(() => {
+    let id: NodeJS.Timeout | undefined;
+    if (timerStart !== null) {
+      id = setInterval(() => {
+        setTimerMs(Date.now() - timerStart);
+      }, 1000);
+    }
+    return () => {
+      if (id) clearInterval(id);
+    };
+  }, [timerStart]);
+
+  const startTimer = () => {
+    setTimerStart(Date.now());
+    setStateTag("RUNNING");
+  };
+
+  const stopTimer = () => {
+    if (timerStart !== null) {
+      setTimerMs(Date.now() - timerStart);
+    }
+    setTimerStart(null);
+    setStateTag("STOPPED");
+  };
+
+  const addScore = (entry: ScoreEntry) => {
+    setScores((prev) => [...prev, entry]);
+  };
+
+  const value: MedicalInterviewContextValue = {
+    timerMs,
+    timerRunning: timerStart !== null,
+    scores,
+    totalScore: scores.reduce((sum, s) => sum + s.points, 0),
+    stateTag,
+    startTimer,
+    stopTimer,
+    addScore,
+    setStateTag,
+  };
+
+  return (
+    <MedicalInterviewContext.Provider value={value}>
+      {children}
+    </MedicalInterviewContext.Provider>
+  );
+};
+
+export function useMedicalInterview() {
+  const ctx = useContext(MedicalInterviewContext);
+  if (!ctx) {
+    throw new Error("useMedicalInterview must be used within a MedicalInterviewProvider");
+  }
+  return ctx;
+}
+
+export type { ScoreEntry };

--- a/src/app/contexts/TranscriptContext.tsx
+++ b/src/app/contexts/TranscriptContext.tsx
@@ -20,6 +20,7 @@ type TranscriptContextValue = {
   ) => void;
   updateTranscriptMessage: (itemId: string, text: string, isDelta: boolean) => void;
   addTranscriptBreadcrumb: (title: string, data?: Record<string, any>) => void;
+  addTranscriptToolCall: (title: string, data?: Record<string, any>) => void;
   toggleTranscriptItemExpand: (itemId: string) => void;
   updateTranscriptItem: (itemId: string, updatedProperties: Partial<TranscriptItem>) => void;
 };
@@ -95,6 +96,23 @@ export const TranscriptProvider: FC<PropsWithChildren> = ({ children }) => {
     ]);
   };
 
+  const addTranscriptToolCall: TranscriptContextValue["addTranscriptToolCall"] = (title, data) => {
+    setTranscriptItems((prev) => [
+      ...prev,
+      {
+        itemId: `tool-${uuidv4()}`,
+        type: "TOOL_CALL",
+        title,
+        data,
+        expanded: false,
+        timestamp: newTimestampPretty(),
+        createdAtMs: Date.now(),
+        status: "DONE",
+        isHidden: false,
+      },
+    ]);
+  };
+
   const toggleTranscriptItemExpand: TranscriptContextValue["toggleTranscriptItemExpand"] = (itemId) => {
     setTranscriptItems((prev) =>
       prev.map((log) =>
@@ -118,6 +136,7 @@ export const TranscriptProvider: FC<PropsWithChildren> = ({ children }) => {
         addTranscriptMessage,
         updateTranscriptMessage,
         addTranscriptBreadcrumb,
+        addTranscriptToolCall,
         toggleTranscriptItemExpand,
         updateTranscriptItem,
       }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,19 @@
 import React, { Suspense } from "react";
 import { TranscriptProvider } from "@/app/contexts/TranscriptContext";
 import { EventProvider } from "@/app/contexts/EventContext";
+import { MedicalInterviewProvider } from "@/app/contexts/MedicalInterviewContext";
 import App from "./App";
 
 export default function Page() {
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <TranscriptProvider>
-        <EventProvider>
-          <App />
-        </EventProvider>
-      </TranscriptProvider>
+      <MedicalInterviewProvider>
+        <TranscriptProvider>
+          <EventProvider>
+            <App />
+          </EventProvider>
+        </TranscriptProvider>
+      </MedicalInterviewProvider>
     </Suspense>
   );
 }

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -67,7 +67,7 @@ export interface GuardrailResultType {
 
 export interface TranscriptItem {
   itemId: string;
-  type: "MESSAGE" | "BREADCRUMB";
+  type: "MESSAGE" | "BREADCRUMB" | "TOOL_CALL";
   role?: "user" | "assistant";
   title?: string;
   data?: Record<string, any>;


### PR DESCRIPTION
## Summary
- add medical interview control panel with timer, score, state, and export features
- track interview metrics via context and log tool calls in transcript
- display tool call rows within transcript

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6c8338d1c83299cfaf67e97c4b3e5