### PR TITLE
Add env example and clarify run instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ There are two main patterns demonstrated:
 
 ## Setup
 
-- This is a Next.js typescript app. Install dependencies with `npm i`.
-- Add your `OPENAI_API_KEY` to your env. Either add it to your `.bash_profile` or equivalent, or copy `.env.sample` to `.env` and add it there.
-- Start the server with `npm run dev`
-- Open your browser to [http://localhost:3000](http://localhost:3000). It should default to the `chatSupervisor` Agent Config.
-- You can change examples via the "Scenario" dropdown in the top right.
+To run the demo locally:
+
+1. Install dependencies with `npm install`.
+2. Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
+3. Start the development server with `npm run dev`.
+4. Open your browser to [http://localhost:3000](http://localhost:3000). It should default to the `chatSupervisor` Agent Config.
+5. You can change examples via the "Scenario" dropdown in the top right.
 
 # Agentic Pattern 1: Chat-Supervisor
 


### PR DESCRIPTION
## Summary
- add `.env.example` file with placeholder `OPENAI_API_KEY` value
- document step-by-step setup and run instructions in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c71157a4fc83299dad0d33b01230e8