### PR TITLE
feat: add patient encounter scenario

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -28,12 +28,17 @@ import { chatSupervisorScenario } from "@/app/agentConfigs/chatSupervisor";
 import { customerServiceRetailCompanyName } from "@/app/agentConfigs/customerServiceRetail";
 import { chatSupervisorCompanyName } from "@/app/agentConfigs/chatSupervisor";
 import { simpleHandoffScenario } from "@/app/agentConfigs/simpleHandoff";
+import {
+  patientEncounter as patientEncounterScenario,
+  patientEncounterCompanyName,
+} from "@/app/agentConfigs/patientEncounter";
 
 // Map used by connect logic for scenarios defined via the SDK.
 const sdkScenarioMap: Record<string, RealtimeAgent[]> = {
   simpleHandoff: simpleHandoffScenario,
   customerServiceRetail: customerServiceRetailScenario,
   chatSupervisor: chatSupervisorScenario,
+  patientEncounter: patientEncounterScenario,
 };
 
 import useAudioDownload from "./hooks/useAudioDownload";
@@ -215,7 +220,9 @@ function App() {
 
         const companyName = agentSetKey === 'customerServiceRetail'
           ? customerServiceRetailCompanyName
-          : chatSupervisorCompanyName;
+          : agentSetKey === 'patientEncounter'
+            ? patientEncounterCompanyName
+            : chatSupervisorCompanyName;
         const guardrail = createModerationGuardrail(companyName);
 
         await connect({

--- a/src/app/agentConfigs/patientEncounter.ts
+++ b/src/app/agentConfigs/patientEncounter.ts
@@ -45,4 +45,8 @@ export function registerPatientEncounterSupervisor(session: RealtimeSession) {
 }
 
 export const patientEncounter = [patientAgent];
+
+// Name of the company represented by this agent set. Used by guardrails
+export const patientEncounterCompanyName = 'General Hospital';
+
 export default patientEncounter;


### PR DESCRIPTION
## Summary
- add patientEncounter scenario to SDK map
- define patient encounter company name for guardrails
- allow selecting patientEncounter agent set

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c72da0fa288329b13b54dddb6561f6