### PR TITLE
Dynamically register patient encounter supervisor

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -31,6 +31,7 @@ import { simpleHandoffScenario } from "@/app/agentConfigs/simpleHandoff";
 import {
   patientEncounter as patientEncounterScenario,
   patientEncounterCompanyName,
+  registerPatientEncounterSupervisor,
 } from "@/app/agentConfigs/patientEncounter";
 
 // Map used by connect logic for scenarios defined via the SDK.
@@ -225,7 +226,7 @@ function App() {
             : chatSupervisorCompanyName;
         const guardrail = createModerationGuardrail(companyName);
 
-        await connect({
+        const session = await connect({
           getEphemeralKey: async () => EPHEMERAL_KEY,
           initialAgents: reorderedAgents,
           audioElement: sdkAudioElement,
@@ -234,6 +235,10 @@ function App() {
             addTranscriptBreadcrumb,
           },
         });
+
+        if (agentSetKey === 'patientEncounter' && session) {
+          registerPatientEncounterSupervisor(session);
+        }
       } catch (err) {
         console.error("Error connecting via SDK:", err);
         setSessionStatus("DISCONNECTED");

--- a/src/app/hooks/useRealtimeSession.ts
+++ b/src/app/hooks/useRealtimeSession.ts
@@ -115,8 +115,8 @@ export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
       audioElement,
       extraContext,
       outputGuardrails,
-    }: ConnectOptions) => {
-      if (sessionRef.current) return; // already connected
+    }: ConnectOptions): Promise<RealtimeSession | undefined> => {
+      if (sessionRef.current) return sessionRef.current; // already connected
 
       updateStatus('CONNECTING');
 
@@ -151,6 +151,7 @@ export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
 
       await sessionRef.current.connect({ apiKey: ek });
       updateStatus('CONNECTED');
+      return sessionRef.current;
     },
     [callbacks, updateStatus],
   );


### PR DESCRIPTION
## Summary
- return connected session from `useRealtimeSession` hook
- register patient encounter supervisor after session connects to log feedback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Type error in medicalInterview/interviewer.ts)*
- `node -e "const { registerPatientEncounterSupervisor, supervisorAgent } = require('./temp-build/patientEncounter.js'); supervisorAgent.run = async () => 'mock feedback'; const EventEmitter = require('events'); const session = new EventEmitter(); registerPatientEncounterSupervisor(session); session.emit('agent_end', {}, { name: 'clinician' }, 'Hello');"`

------
https://chatgpt.com/codex/tasks/task_e_68c72f20d5e88329816b9a5c78a9f820